### PR TITLE
feat: adapt code to version 2023.1.1

### DIFF
--- a/exts/stride.simulator/stride/simulator/backends/ros2_backend.py
+++ b/exts/stride.simulator/stride/simulator/backends/ros2_backend.py
@@ -8,7 +8,7 @@ from omni.isaac.core.utils.extensions import disable_extension, enable_extension
 
 # # Perform some checks, because Isaac Sim some times does not play nice when using ROS/ROS2
 disable_extension("omni.isaac.ros_bridge")
-enable_extension("omni.isaac.ros2_bridge-humble")
+enable_extension("omni.isaac.ros2_bridge")
 
 # Inform the user that now we are actually import the ROS2 dependencies
 # Note: we are performing the imports here to make sure that ROS2 extension was load correctly
@@ -254,20 +254,3 @@ class ROS2Backend(Backend):
         self.twist_pub.publish(twist)
         self.twist_inertial_pub.publish(twist_inertial)
         self.accel_pub.publish(accel)
-
-    # def check_ros_extension(self):
-    #     """
-    #     Method that checks which ROS extension is installed.
-    #     """
-
-    #     # Get the handle for the extension manager
-    #     extension_manager = omni.kit.app.get_app().get_extension_manager()
-
-    #     version = ""
-
-    #     if self._ext_manager.is_extension_enabled("omni.isaac.ros_bridge"):
-    #         version = "ros"
-    #     elif self._ext_manager.is_extension_enabled("omni.isaac.ros2_bridge"):
-    #         version = "ros2"
-    #     else:
-    #         carb.log_warn("Neither extension 'omni.isaac.ros_bridge' nor 'omni.isaac.ros2_bridge' is enabled")

--- a/exts/stride.simulator/stride/simulator/params.py
+++ b/exts/stride.simulator/stride/simulator/params.py
@@ -57,7 +57,7 @@ for asset, path in NVIDIA_SIMULATION_ENVIRONMENTS.items():
 
 # Define the default settings for the simulation environment
 DEFAULT_WORLD_SETTINGS = {
-    "physics_dt": 1.0 / 200.0,
+    "physics_dt": 1.0 / 800.0,
     "stage_units_in_meters": 1.0,
     "rendering_dt": 1.0 / 60.0,
 }

--- a/exts/stride.simulator/stride/simulator/vehicles/sensors/lidar.py
+++ b/exts/stride.simulator/stride/simulator/vehicles/sensors/lidar.py
@@ -78,7 +78,7 @@ class Lidar(Sensor):
                 self._lidar.set_resolution([0.4, 0.4])
                 self._lidar.set_valid_range([0.1, 6])
                 self._lidar.enable_visualization(
-                    high_lod=True, draw_points=True, draw_lines=False
+                    high_lod=True, draw_points=False, draw_lines=False
                 )
 
                 self.lidar_flag_ = True


### PR DESCRIPTION
# 버전 업그레이드

## 변경 사항 요약

-  2022.2.1은 너무 구닥다리라서, nvidia graphic driver를 많이 탐.
-  2023.1.1은 다양한 lidar configuration을 지원함. 사용하기 용이함

## 테스트 방법

-   2023.1.1부터는 오히려 ros2가 등록이 되어 있어야함

```bash
source /opt/ros/humble/setup.bash

ISAACSIM
```

- 사실 isaacsim의 ros2 plugin을 사용하지 않기에 나중에 아래 코드는 삭제를 고려해봐도 좋을듯
https://github.com/mqjinwon/StrideSim/blob/715b8b0e70e897bdb2defd9ddbf0a61a4606a17b/exts/stride.simulator/stride/simulator/backends/ros2_backend.py#L11

## 기타 고려 사항
-  2023.1.1부터는 물리법칙이 조금 달라진 것으로 보임
- physics_dt를 원래 1/200 에서 1/800으로 바꿈, 그러니 anymal_c가 걸음
- 장기적으로 2023.1.1 코드를 main branch로 병합하고자 함